### PR TITLE
Updating name binding

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -2,18 +2,18 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-unsigned short int op_score(op o) {
+unsigned short int op_score(bin_op o) {
 	switch(o) {
-	case OP_ADD: case OP_SUB:
+	case BIN_ADD: case BIN_SUB:
 		return 1;
-	case OP_MULT: case OP_DIV: case OP_MOD:
+	case BIN_MULT: case BIN_DIV: case BIN_MOD:
 		return 2;
 	default:
 		return 0;
 	}
 }
 
-bool higher_precedence(op higher, op lower) {
+bool higher_precedence(bin_op higher, bin_op lower) {
 	return op_score(higher) > op_score(lower);
 }
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -18,8 +18,15 @@ typedef enum data_type {
 	T_STR = TOK_STRING,
 	T_BOOL = TOK_BOOL,
 	T_BYTE = TOK_BYTE,
-	T_CUSTOM = TOK_IDENT, // Needs to be determined later.
+	T_CUSTOM = TOK_IDENT, // Needs to be looked up in symbol table.
+	T_INFERRED, // Type can't be determined until assignment is evaulated.
 } data_type;
+
+typedef enum bind_type {
+	BIND_LET,
+	BIND_STATIC,
+	BIND_CONST,
+} bind_type;
 
 typedef enum un_op {
 	UN_REF = TOK_AND,
@@ -56,7 +63,6 @@ typedef enum log_op {
 
 typedef enum as_op {
 	AS_ASSIGN = TOK_ASSIGN,
-	AS_INF_ASSIGN = TOK_INF_ASSIGN,
 	AS_ADD_ASSIGN = TOK_PLUS_ASSIGN,
 	AS_SUB_ASSIGN = TOK_MINUS_ASSIGN,
 	AS_MULT_ASSIGN = TOK_MULT_ASSIGN,
@@ -124,6 +130,7 @@ typedef struct expr_group {
 } expr_group;
 
 typedef struct expr_var_decl {
+	bind_type binding;
 	data_type type;
 	size_t type_ident;
 	size_t name;

--- a/src/lex.c
+++ b/src/lex.c
@@ -41,7 +41,7 @@ const char *reserved_map[] = {
 	[TOK_LOGICAL_AND] = "&&",
 	[TOK_LOGICAL_OR] = "||",
 	[TOK_SHIFT_LEFT] = "<<",
-	[TOK_SHIFT_ASSIGN] = ">>",
+	[TOK_SHIFT_RIGHT] = ">>",
 	[TOK_PLUS_ASSIGN] = "+=",
 	[TOK_MINUS_ASSIGN] = "-=",
 	[TOK_MULT_ASSIGN] = "*=",
@@ -52,8 +52,6 @@ const char *reserved_map[] = {
 	[TOK_AND_ASSIGN] = "&=",
 	[TOK_OR_ASSIGN] = "|=",
 	[TOK_XOR_ASSIGN] = "^=",
-	[TOK_INF_ASSIGN] = ":=",
-	[TOK_PTR_REF] = "->",
 
 	[TOK_FN] = "fn",
 	[TOK_SWITCH] = "switch",
@@ -66,6 +64,9 @@ const char *reserved_map[] = {
 	[TOK_SIZEOF] = "sizeof",
 	[TOK_FOR] = "for",
 	[TOK_WHILE] = "while",
+	[TOK_LET] = "let",
+	[TOK_STATIC] = "static",
+	[TOK_CONST] = "const",
 	[TOK_U8] = "u8",
 	[TOK_U16] = "u16",
 	[TOK_U32] = "u32",
@@ -472,8 +473,8 @@ char *get_type_name(token_type t) {
 		return "TOK_LOGICAL_OR";
 	case TOK_SHIFT_LEFT:
 		return "TOK_SHIFT_LEFT";
-	case TOK_SHIFT_ASSIGN:
-		return "TOK_SHIFT_ASSIGN";
+	case TOK_SHIFT_RIGHT:
+		return "TOK_SHIFT_RIGHT";
 	case TOK_PLUS_ASSIGN:
 		return "TOK_PLUS_ASSIGN";
 	case TOK_MINUS_ASSIGN:
@@ -494,10 +495,6 @@ char *get_type_name(token_type t) {
 		return "TOK_OR_ASSIGN";
 	case TOK_XOR_ASSIGN:
 		return "TOK_XOR_ASSIGN";
-	case TOK_PTR_REF:
-		return "TOK_PTR_REF";
-	case TOK_INF_ASSIGN:
-		return "TOK_INF_ASSIGN";
 	case TOK_FN:
 		return "TOK_FN";
 	case TOK_SWITCH:
@@ -516,6 +513,16 @@ char *get_type_name(token_type t) {
 		return "TOK_ELSE";
 	case TOK_SIZEOF:
 		return "TOK_SIZEOF";
+	case TOK_FOR:
+		return "TOK_FOR";
+	case TOK_WHILE:
+		return "TOK_WHILE";
+	case TOK_LET:
+		return "TOK_LET";
+	case TOK_STATIC:
+		return "TOK_STATIC";
+	case TOK_CONST:
+		return "TOK_CONST";
 	case TOK_U8:
 		return "TOK_U8";
 	case TOK_U16:

--- a/src/lex.h
+++ b/src/lex.h
@@ -61,8 +61,7 @@ typedef enum token_type {
 	TOK_SHIFT_RIGHT_ASSIGN,
 	TOK_AND_ASSIGN,
 	TOK_OR_ASSIGN,
-	TOK_XOR_ASSIGN,
-	TOK_INF_ASSIGN, // This MUST be the last symbol token.
+	TOK_XOR_ASSIGN, // This MUST be the last symbol token.
 
 	TOK_FN,
 	TOK_SWITCH,
@@ -75,6 +74,9 @@ typedef enum token_type {
 	TOK_SIZEOF,
 	TOK_FOR,
 	TOK_WHILE,
+	TOK_LET,
+	TOK_STATIC,
+	TOK_CONST,
 	TOK_U8,
 	TOK_U16,
 	TOK_U32,


### PR DESCRIPTION
Introduced `let`, `static`, and `const` keywords to make variable declaration parsing MUCH easier, and casts can just be parsed as function calls. When symbol resolution kicks in, the proper casting functions can be pulled in even if they're overloaded